### PR TITLE
Support links within angled brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linkify Changelog
 
+### v2.1.1
+
+* Avoid including angle brackets in links.
+
 ### v2.1.0
 
 #### BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkifyjs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Intelligent link recognition, made easy",
   "repository": {
     "type": "git",

--- a/src/linkify/core/parser.js
+++ b/src/linkify/core/parser.js
@@ -35,9 +35,11 @@ import {
 	TLD,
 	OPENBRACE,
 	OPENBRACKET,
+	OPENANGLEBRACKET,
 	OPENPAREN,
 	CLOSEBRACE,
 	CLOSEBRACKET,
+	CLOSEANGLEBRACKET,
 	CLOSEPAREN,
 } from './tokens/text';
 
@@ -67,12 +69,15 @@ let S_URL					= makeState(URL); // Long URL with optional port and maybe query s
 let S_URL_NON_ACCEPTING		= makeState(); // URL followed by some symbols (will not be part of the final URL)
 let S_URL_OPENBRACE			= makeState(); // URL followed by {
 let S_URL_OPENBRACKET		= makeState(); // URL followed by [
+let S_URL_OPENANGLEBRACKET		= makeState(); // URL followed by <
 let S_URL_OPENPAREN			= makeState(); // URL followed by (
 let S_URL_OPENBRACE_Q		= makeState(URL); // URL followed by { and some symbols that the URL can end it
 let S_URL_OPENBRACKET_Q		= makeState(URL); // URL followed by [ and some symbols that the URL can end it
+let S_URL_OPENANGLEBRACKET_Q		= makeState(URL); // URL followed by < and some symbols that the URL can end it
 let S_URL_OPENPAREN_Q		= makeState(URL); // URL followed by ( and some symbols that the URL can end it
 let S_URL_OPENBRACE_SYMS	= makeState(); // S_URL_OPENBRACE_Q followed by some symbols it cannot end it
 let S_URL_OPENBRACKET_SYMS	= makeState(); // S_URL_OPENBRACKET_Q followed by some symbols it cannot end it
+let S_URL_OPENANGLEBRACKET_SYMS	= makeState(); // S_URL_OPENANGLEBRACKET_Q followed by some symbols it cannot end it
 let S_URL_OPENPAREN_SYMS	= makeState(); // S_URL_OPENPAREN_Q followed by some symbols it cannot end it
 let S_EMAIL_DOMAIN			= makeState(); // parsed string starts with local email info + @ with a potential domain name (C)
 let S_EMAIL_DOMAIN_DOT		= makeState(); // (C) domain followed by DOT
@@ -167,9 +172,11 @@ let qsNonAccepting = [
 	PUNCTUATION,
 	CLOSEBRACE,
 	CLOSEBRACKET,
+	CLOSEANGLEBRACKET,
 	CLOSEPAREN,
 	OPENBRACE,
 	OPENBRACKET,
+	OPENANGLEBRACKET,
 	OPENPAREN
 ];
 
@@ -191,12 +198,15 @@ S_URL_NON_ACCEPTING
 // Closing bracket component. This character WILL be included in the URL
 S_URL_OPENBRACE.on(CLOSEBRACE, S_URL);
 S_URL_OPENBRACKET.on(CLOSEBRACKET, S_URL);
+S_URL_OPENANGLEBRACKET.on(CLOSEANGLEBRACKET, S_URL);
 S_URL_OPENPAREN.on(CLOSEPAREN, S_URL);
 S_URL_OPENBRACE_Q.on(CLOSEBRACE, S_URL);
 S_URL_OPENBRACKET_Q.on(CLOSEBRACKET, S_URL);
+S_URL_OPENANGLEBRACKET_Q.on(CLOSEANGLEBRACKET, S_URL);
 S_URL_OPENPAREN_Q.on(CLOSEPAREN, S_URL);
 S_URL_OPENBRACE_SYMS.on(CLOSEBRACE, S_URL);
 S_URL_OPENBRACKET_SYMS.on(CLOSEBRACKET, S_URL);
+S_URL_OPENANGLEBRACKET_SYMS.on(CLOSEANGLEBRACKET, S_URL);
 S_URL_OPENPAREN_SYMS.on(CLOSEPAREN, S_URL);
 
 // URL that beings with an opening bracket, followed by a symbols.
@@ -204,24 +214,30 @@ S_URL_OPENPAREN_SYMS.on(CLOSEPAREN, S_URL);
 // has a single opening bracket for some reason).
 S_URL_OPENBRACE.on(qsAccepting, S_URL_OPENBRACE_Q);
 S_URL_OPENBRACKET.on(qsAccepting, S_URL_OPENBRACKET_Q);
+S_URL_OPENANGLEBRACKET.on(qsAccepting, S_URL_OPENANGLEBRACKET_Q);
 S_URL_OPENPAREN.on(qsAccepting, S_URL_OPENPAREN_Q);
 S_URL_OPENBRACE.on(qsNonAccepting, S_URL_OPENBRACE_SYMS);
 S_URL_OPENBRACKET.on(qsNonAccepting, S_URL_OPENBRACKET_SYMS);
+S_URL_OPENANGLEBRACKET.on(qsNonAccepting, S_URL_OPENANGLEBRACKET_SYMS);
 S_URL_OPENPAREN.on(qsNonAccepting, S_URL_OPENPAREN_SYMS);
 
 // URL that begins with an opening bracket, followed by some symbols
 S_URL_OPENBRACE_Q.on(qsAccepting, S_URL_OPENBRACE_Q);
 S_URL_OPENBRACKET_Q.on(qsAccepting, S_URL_OPENBRACKET_Q);
+S_URL_OPENANGLEBRACKET_Q.on(qsAccepting, S_URL_OPENANGLEBRACKET_Q);
 S_URL_OPENPAREN_Q.on(qsAccepting, S_URL_OPENPAREN_Q);
 S_URL_OPENBRACE_Q.on(qsNonAccepting, S_URL_OPENBRACE_Q);
 S_URL_OPENBRACKET_Q.on(qsNonAccepting, S_URL_OPENBRACKET_Q);
+S_URL_OPENANGLEBRACKET_Q.on(qsNonAccepting, S_URL_OPENANGLEBRACKET_Q);
 S_URL_OPENPAREN_Q.on(qsNonAccepting, S_URL_OPENPAREN_Q);
 
 S_URL_OPENBRACE_SYMS.on(qsAccepting, S_URL_OPENBRACE_Q);
 S_URL_OPENBRACKET_SYMS.on(qsAccepting, S_URL_OPENBRACKET_Q);
+S_URL_OPENANGLEBRACKET_SYMS.on(qsAccepting, S_URL_OPENANGLEBRACKET_Q);
 S_URL_OPENPAREN_SYMS.on(qsAccepting, S_URL_OPENPAREN_Q);
 S_URL_OPENBRACE_SYMS.on(qsNonAccepting, S_URL_OPENBRACE_SYMS);
 S_URL_OPENBRACKET_SYMS.on(qsNonAccepting, S_URL_OPENBRACKET_SYMS);
+S_URL_OPENANGLEBRACKET_SYMS.on(qsNonAccepting, S_URL_OPENANGLEBRACKET_SYMS);
 S_URL_OPENPAREN_SYMS.on(qsNonAccepting, S_URL_OPENPAREN_SYMS);
 
 // Account for the query string

--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -26,9 +26,11 @@ import {
 	COLON,
 	OPENBRACE,
 	OPENBRACKET,
+	OPENANGLEBRACKET,
 	OPENPAREN,
 	CLOSEBRACE,
 	CLOSEBRACKET,
+	CLOSEANGLEBRACKET,
 	CLOSEPAREN,
 	PUNCTUATION,
 	NL,
@@ -63,9 +65,11 @@ S_START
 .on(':', makeState(COLON))
 .on('{', makeState(OPENBRACE))
 .on('[', makeState(OPENBRACKET))
+.on('<', makeState(OPENANGLEBRACKET))
 .on('(', makeState(OPENPAREN))
 .on('}', makeState(CLOSEBRACE))
 .on(']', makeState(CLOSEBRACKET))
+.on('>', makeState(CLOSEANGLEBRACKET))
 .on(')', makeState(CLOSEPAREN))
 .on([',', ';', '!', '"'], makeState(PUNCTUATION));
 

--- a/src/linkify/core/tokens/text.js
+++ b/src/linkify/core/tokens/text.js
@@ -153,9 +153,11 @@ const WS = inheritsToken();
 
 const OPENBRACE = inheritsToken('{');
 const OPENBRACKET = inheritsToken('[');
+const OPENANGLEBRACKET = inheritsToken('<');
 const OPENPAREN = inheritsToken('(');
 const CLOSEBRACE = inheritsToken('}');
 const CLOSEBRACKET = inheritsToken(']');
+const CLOSEANGLEBRACKET = inheritsToken('>');
 const CLOSEPAREN = inheritsToken(')');
 
 export {
@@ -179,8 +181,10 @@ export {
 	WS,
 	OPENBRACE,
 	OPENBRACKET,
+	OPENANGLEBRACKET,
 	OPENPAREN,
 	CLOSEBRACE,
 	CLOSEBRACKET,
+	CLOSEANGLEBRACKET,
 	CLOSEPAREN
 };


### PR DESCRIPTION
Fixes an issue where text like `<http://org2.salsalabs.com/dia/track.jsp?v=2&c=t8nF%2FpdT%2FV4LKI6BW8SoquTR8IIhZl3X>` would result in links that include the trailing `>`.
